### PR TITLE
Add ETL script to build SQLite DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+asset_atlas.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
-# Asset-Atlas
+# Asset Atlas
+
+This repository contains data from the General Services Administration's
+**Inventory of Owned and Leased Properties (IOLP)**.  The Excel files
+`2025-6-20-iolp-buildings.xlsx` and `2025-6-20-iolp-leases.xlsx` were
+exported from the IOLP website.
+
+The accompanying XML metadata explains each field of the datasets.  It
+notes in part:
+
+```
+The Owned and Leased Data Sets include the following data except where
+noted below for Leases:Location Code - GSA’s alphanumeric identifier for
+the buildingReal Property Asset Name - Allows users to find information
+about a specific building Installation Name - Allows users to identify
+whether a property is part of an installation, such as a campusOwned or
+Leased - Indicates the building is federally owned (F) or leased (L)GSA
+Region - GSA assigned region for building locationStreet Address -
+Building addressCity - Building CityState - Building StateZip Code -
+Building ZipLatitude and Longitude - Map coordinates of the building
+(only through .csv export)Rentable Square Feet - Total rentable square
+feet in buildingAvailable Square Feet - Vacant space in building
+Construction Date (Owned Only)- Year builtCongressional District -
+Congressional District building is locatedRepresentative -
+Representative of the Congressional DistrictBuilding Status (Owned
+Only)- Indicates building is activeLease Number (Leased Only) - GSA’s
+alphanumeric identifier for the leaseLease Effective/Expiration Dates
+(Leased Only) - Date lease starts/expiresReal Property Asset Type -
+Identifies a property as land, building, or structure
+```
+
+## Database creation
+
+Run the ETL script after installing its Python dependencies:
+
+```bash
+pip install pandas openpyxl
+python etl.py
+```
+
+The script reads both spreadsheets, cleans the building names and
+creates `asset_atlas.db`, a SQLite database with the following tables:
+
+- **addresses** – unique combination of street address, city, state,
+  and ZIP code with geolocation and congressional district data.
+- **properties** – building details keyed by the IOLP `Location Code`.
+  Each property references an address and includes both the original and
+  cleaned asset name.
+- **leases** – lease information for properties that are leased.
+
+## Cleaning building names
+
+Building names sometimes contain the address.  The script attempts to
+remove the street address from the `Real Property Asset Name` column with
+this heuristic:
+
+```python
+pattern = re.escape(addr.strip())
+cleaned = re.sub(pattern, '', name, flags=re.IGNORECASE).strip()
+cleaned = re.sub(r'\s+', ' ', cleaned)
+```
+
+Because addresses vary in format (for example `AVENUE` vs `AVE`), the
+result is not perfect but it captures many cases.

--- a/etl.py
+++ b/etl.py
@@ -1,0 +1,135 @@
+import pandas as pd
+import sqlite3
+import re
+
+# Load Excel data
+buildings = pd.read_excel('2025-6-20-iolp-buildings.xlsx')
+leases = pd.read_excel('2025-6-20-iolp-leases.xlsx')
+
+# Clean building names by removing street address if it appears in the name
+# This is a simple heuristic and may not perfectly cleanse all names.
+def clean_asset_name(row):
+    name = row['Real Property Asset Name']
+    addr = row['Street Address']
+    if isinstance(name, str) and isinstance(addr, str):
+        pattern = re.escape(addr.strip())
+        cleaned = re.sub(pattern, '', name, flags=re.IGNORECASE).strip()
+        cleaned = re.sub(r'\s+', ' ', cleaned)
+        return cleaned
+    return name
+
+buildings['Clean Asset Name'] = buildings.apply(clean_asset_name, axis=1)
+
+# Create SQLite database
+conn = sqlite3.connect('asset_atlas.db')
+cur = conn.cursor()
+
+# Addresses table
+cur.execute('''
+CREATE TABLE IF NOT EXISTS addresses (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    street_address TEXT,
+    city TEXT,
+    state TEXT,
+    zip_code TEXT,
+    latitude REAL,
+    longitude REAL,
+    congressional_district TEXT,
+    congressional_rep TEXT,
+    UNIQUE(street_address, city, state, zip_code)
+)
+''')
+
+# Properties table
+cur.execute('''
+CREATE TABLE IF NOT EXISTS properties (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    location_code TEXT UNIQUE,
+    asset_name TEXT,
+    clean_asset_name TEXT,
+    installation_name TEXT,
+    owned_or_leased TEXT,
+    gsa_region TEXT,
+    address_id INTEGER,
+    rentable_sqft REAL,
+    available_sqft REAL,
+    construction_date TEXT,
+    building_status TEXT,
+    asset_type TEXT,
+    FOREIGN KEY(address_id) REFERENCES addresses(id)
+)
+''')
+
+# Leases table
+cur.execute('''
+CREATE TABLE IF NOT EXISTS leases (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    property_id INTEGER,
+    federal_leased_code TEXT,
+    lease_number TEXT,
+    lease_effective_date TEXT,
+    lease_expiration_date TEXT,
+    FOREIGN KEY(property_id) REFERENCES properties(id)
+)
+''')
+conn.commit()
+
+# Helper: get or create address
+def get_address_id(row):
+    cur.execute('''SELECT id FROM addresses WHERE street_address=? AND city=? AND state=? AND zip_code=?''',
+                (row['Street Address'], row['City'], row['State'], str(row['Zip Code'])))
+    res = cur.fetchone()
+    if res:
+        return res[0]
+    cur.execute('''INSERT INTO addresses (street_address, city, state, zip_code, latitude, longitude,
+                   congressional_district, congressional_rep)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)''',
+                (row['Street Address'], row['City'], row['State'], str(row['Zip Code']),
+                 row['Latitude'], row['Longitude'],
+                 row.get('Congressional District'), row.get('Congressional District Representative Name') or row.get('Congressional District Representative')))
+    conn.commit()
+    return cur.lastrowid
+
+# Insert buildings as properties
+for _, row in buildings.iterrows():
+    addr_id = get_address_id(row)
+    cur.execute('''INSERT OR IGNORE INTO properties
+                (location_code, asset_name, clean_asset_name, installation_name,
+                 owned_or_leased, gsa_region, address_id, rentable_sqft, available_sqft,
+                 construction_date, building_status, asset_type)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                (row['Location Code'], row['Real Property Asset Name'], row['Clean Asset Name'],
+                 row['Installation Name'], row['Owned or Leased'], row['GSA Region'], addr_id,
+                 row['Building Rentable Square Feet'], row['Available Square Feet'],
+                 row.get('Construction Date'), row.get('Building Status'), row['Real Property Asset Type']))
+conn.commit()
+
+# Map location code to property id
+code_to_id = {r[1]: r[0] for r in cur.execute('SELECT id, location_code FROM properties')}
+
+# Insert leases
+for _, row in leases.iterrows():
+    prop_id = code_to_id.get(row['Location Code'])
+    if not prop_id:
+        addr_id = get_address_id(row)
+        clean_name = clean_asset_name(row)
+        cur.execute('''INSERT OR IGNORE INTO properties
+                    (location_code, asset_name, clean_asset_name, installation_name,
+                     owned_or_leased, gsa_region, address_id, rentable_sqft, available_sqft,
+                     construction_date, building_status, asset_type)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''',
+                    (row['Location Code'], row['Real Property Asset Name'], clean_name,
+                     row['Installation Name'], 'L', row['GSA Region'], addr_id,
+                     row['Building Rentable Square Feet'], row['Available Square Feet'],
+                     None, None, row['Real Property Asset type']))
+        conn.commit()
+        prop_id = cur.lastrowid
+        code_to_id[row['Location Code']] = prop_id
+    cur.execute('''INSERT INTO leases
+                (property_id, federal_leased_code, lease_number, lease_effective_date, lease_expiration_date)
+                VALUES (?, ?, ?, ?, ?)''',
+                (prop_id, row['Federal Leased Code'], row['Lease Number'],
+                 str(row.get('Lease Effective Date')), str(row.get('Lease Expiration Date'))))
+conn.commit()
+conn.close()
+print('Database created as asset_atlas.db')


### PR DESCRIPTION
## Summary
- add ETL helper to import Excel files
- normalize addresses, properties, leases into SQLite
- document dataset and cleaning steps

## Testing
- `pip install pandas openpyxl`
- `python3 etl.py`
- `sqlite3 asset_atlas.db 'SELECT count(*) FROM properties;'`
- `sqlite3 asset_atlas.db 'SELECT count(*) FROM leases;'`


------
https://chatgpt.com/codex/tasks/task_b_685efbbdbfd8832d8e7ea48099a562e9