### PR TITLE
Add Flask data table page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 asset_atlas.db
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -62,3 +62,18 @@ cleaned = re.sub(r'\s+', ' ', cleaned)
 
 Because addresses vary in format (for example `AVENUE` vs `AVE`), the
 result is not perfect but it captures many cases.
+
+## Simple web interface
+
+The `webapp` directory contains a small Flask application that loads the
+building spreadsheet and exposes a page to explore the data.  Install
+the dependencies listed in `requirements.txt` and run `webapp/app.py`:
+
+```bash
+pip install -r requirements.txt
+python webapp/app.py
+```
+
+Navigate to <http://localhost:5000/> to see a filterable table showing
+property name, address, construction date, and whether the building is
+owned or leased.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pandas
+openpyxl

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -33,6 +33,8 @@ _df = _df.rename(columns={
     'Construction Date': 'construction_date',
     'Owned or Leased': 'owned_or_leased'
 })
+# Convert numeric construction_date values to strings for JSON serialization
+_df['construction_date'] = _df['construction_date'].apply(lambda x: str(int(x)) if pd.notnull(x) else '')
 
 @app.route('/')
 def properties_page():

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,0 +1,48 @@
+from flask import Flask, render_template, jsonify
+import pandas as pd
+from pathlib import Path
+
+app = Flask(__name__)
+
+# Determine the path to the Excel file relative to this file
+DATA_PATH = Path(__file__).resolve().parent.parent / '2025-6-20-iolp-buildings.xlsx'
+
+# Load a subset of the building dataset with relevant fields
+_df = pd.read_excel(
+    DATA_PATH,
+    usecols=[
+        'Real Property Asset Name',
+        'Street Address',
+        'City',
+        'State',
+        'Construction Date',
+        'Owned or Leased'
+    ]
+)
+
+# Combine address fields into a single column
+_df['Address'] = (
+    _df['Street Address'].fillna('') + ', ' +
+    _df['City'].fillna('') + ', ' +
+    _df['State'].fillna('')
+)
+
+# Rename columns for friendlier JSON keys
+_df = _df.rename(columns={
+    'Real Property Asset Name': 'name',
+    'Construction Date': 'construction_date',
+    'Owned or Leased': 'owned_or_leased'
+})
+
+@app.route('/')
+def properties_page():
+    """Render the table page."""
+    return render_template('properties.html')
+
+@app.route('/api/properties')
+def properties_api():
+    """Return the dataset as JSON for DataTables."""
+    return jsonify(_df[['name', 'Address', 'construction_date', 'owned_or_leased']].to_dict(orient='records'))
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/webapp/templates/properties.html
+++ b/webapp/templates/properties.html
@@ -22,7 +22,10 @@
 <script>
 $(document).ready(function() {
     $('#properties').DataTable({
-        ajax: '/api/properties',
+        ajax: {
+            url: '/api/properties',
+            dataSrc: ''
+        },
         columns: [
             { data: 'name' },
             { data: 'Address' },

--- a/webapp/templates/properties.html
+++ b/webapp/templates/properties.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Property List</title>
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css" />
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+</head>
+<body>
+<h1>Federal Properties</h1>
+<table id="properties" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th>Name</th>
+            <th>Address</th>
+            <th>Construction Date</th>
+            <th>Owned or Leased</th>
+        </tr>
+    </thead>
+</table>
+<script>
+$(document).ready(function() {
+    $('#properties').DataTable({
+        ajax: '/api/properties',
+        columns: [
+            { data: 'name' },
+            { data: 'Address' },
+            { data: 'construction_date' },
+            { data: 'owned_or_leased' }
+        ]
+    });
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask webapp for exploring buildings spreadsheet
- include HTML template using DataTables
- document how to run the simple web interface
- add runtime Python requirements

## Testing
- `python -m py_compile webapp/app.py`

------
https://chatgpt.com/codex/tasks/task_b_686341a389b4832d88c631b19172df93