### PR TITLE
Add owned properties dashboard page

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -46,5 +46,24 @@ def properties_api():
     """Return the dataset as JSON for DataTables."""
     return jsonify(_df[['name', 'Address', 'construction_date', 'owned_or_leased']].to_dict(orient='records'))
 
+
+@app.route('/owned')
+def owned_dashboard():
+    """Render dashboard for owned properties."""
+    return render_template('owned_dashboard.html')
+
+
+@app.route('/api/owned_construction_dates')
+def owned_construction_dates():
+    """Return counts of owned buildings by construction year."""
+    owned = _df[_df['owned_or_leased'] == 'F']
+    counts = owned['construction_date'].value_counts().sort_index()
+    data = [
+        {'year': year, 'count': int(count)}
+        for year, count in counts.items()
+        if year
+    ]
+    return jsonify(data)
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/webapp/templates/owned_dashboard.html
+++ b/webapp/templates/owned_dashboard.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Owned Properties Dashboard</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">Asset Atlas</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="/">Properties</a></li>
+        <li class="nav-item"><a class="nav-link disabled" href="#">Map</a></li>
+        <li class="nav-item"><a class="nav-link active" aria-current="page" href="/owned">Owned Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link disabled" href="#">Leased Dashboard</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h1 class="card-title mb-4">Owned Properties Construction Dates</h1>
+      <canvas id="constructionChart" height="100"></canvas>
+    </div>
+  </div>
+</div>
+<script>
+$(function() {
+    $.getJSON('/api/owned_construction_dates', function(data) {
+        const years = data.map(d => d.year);
+        const counts = data.map(d => d.count);
+        const ctx = document.getElementById('constructionChart');
+        new Chart(ctx, {
+            type: 'bar',
+            data: {
+                labels: years,
+                datasets: [{
+                    label: 'Buildings',
+                    data: counts,
+                    backgroundColor: 'rgba(54, 162, 235, 0.6)'
+                }]
+            },
+            options: {
+                scales: {
+                    y: { beginAtZero: true }
+                }
+            }
+        });
+    });
+});
+</script>
+</body>
+</html>

--- a/webapp/templates/properties.html
+++ b/webapp/templates/properties.html
@@ -21,7 +21,7 @@
       <ul class="navbar-nav">
         <li class="nav-item"><a class="nav-link active" aria-current="page" href="/">Properties</a></li>
         <li class="nav-item"><a class="nav-link disabled" href="#">Map</a></li>
-        <li class="nav-item"><a class="nav-link disabled" href="#">Owned Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="/owned">Owned Dashboard</a></li>
         <li class="nav-item"><a class="nav-link disabled" href="#">Leased Dashboard</a></li>
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- enable navigation to Owned Dashboard
- add new Owned Dashboard page
- include Chart.js bar chart of owned properties by construction date
- provide API endpoints for chart data

## Testing
- `python -m py_compile webapp/app.py`

------
https://chatgpt.com/codex/tasks/task_b_686352f06358832d806fd60fd70568f8