### PR TITLE
Add map to owned properties dashboard

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -16,7 +16,12 @@ _df = pd.read_excel(
         'City',
         'State',
         'Construction Date',
-        'Owned or Leased'
+        'Owned or Leased',
+        'Latitude',
+        'Longitude',
+        'Building Status',
+        'Real Property Asset Type',
+        'Congressional District Representative Name'
     ]
 )
 
@@ -31,7 +36,12 @@ _df['Address'] = (
 _df = _df.rename(columns={
     'Real Property Asset Name': 'name',
     'Construction Date': 'construction_date',
-    'Owned or Leased': 'owned_or_leased'
+    'Owned or Leased': 'owned_or_leased',
+    'Latitude': 'lat',
+    'Longitude': 'lon',
+    'Building Status': 'building_status',
+    'Real Property Asset Type': 'asset_type',
+    'Congressional District Representative Name': 'representative'
 })
 
 _df['construction_date'] = _df['construction_date'].apply(lambda x: str(int(x)) if pd.notnull(x) else '')
@@ -64,6 +74,23 @@ def owned_construction_dates():
         if year
     ]
     return jsonify(data)
+
+
+@app.route('/api/owned_map_data')
+def owned_map_data():
+    """Return location data for owned properties."""
+    owned = _df[_df['owned_or_leased'] == 'F']
+    records = []
+    for _, row in owned.iterrows():
+        if pd.notnull(row['lat']) and pd.notnull(row['lon']):
+            records.append({
+                'lat': float(row['lat']),
+                'lon': float(row['lon']),
+                'status': row.get('building_status', ''),
+                'asset_type': row.get('asset_type', ''),
+                'representative': row.get('representative', '')
+            })
+    return jsonify(records)
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/webapp/templates/owned_dashboard.html
+++ b/webapp/templates/owned_dashboard.html
@@ -7,6 +7,8 @@
     <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 </head>
 <body>
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
@@ -32,6 +34,12 @@
       <canvas id="constructionChart" height="100"></canvas>
     </div>
   </div>
+  <div class="card shadow-sm mt-4">
+    <div class="card-body">
+      <h1 class="card-title mb-4">Owned Properties Map</h1>
+      <div id="map" style="height: 500px;"></div>
+    </div>
+  </div>
 </div>
 <script>
 $(function() {
@@ -54,6 +62,22 @@ $(function() {
                     y: { beginAtZero: true }
                 }
             }
+        });
+    });
+
+    const map = L.map('map').setView([39.5, -98.35], 4);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    $.getJSON('/api/owned_map_data', function(locations) {
+        locations.forEach(function(loc) {
+            L.marker([loc.lat, loc.lon]).addTo(map)
+                .bindPopup(
+                    '<strong>Status:</strong> ' + loc.status + '<br>' +
+                    '<strong>Type:</strong> ' + loc.asset_type + '<br>' +
+                    '<strong>Rep:</strong> ' + loc.representative
+                );
         });
     });
 });


### PR DESCRIPTION
## Summary
- extend dataset loading with location and status columns
- add API route `/api/owned_map_data`
- show Leaflet map on owned dashboard

## Testing
- `python -m py_compile etl.py webapp/app.py`
- `python webapp/app.py` *(manual smoke test of new API)*

------
https://chatgpt.com/codex/tasks/task_b_68635676bd5c832d8504b89b33b951f1