### PR TITLE
Add leased properties dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,4 +78,6 @@ Navigate to <http://localhost:5000/> to see a filterable table showing
 property name, address, construction date, and whether the building is
 owned or leased.  The interface now uses Bootstrap and DataTables for a
 modern look with sorting and paging controls.  A navigation bar at the
-top provides links to future dashboard pages.
+top provides links to an **Owned Dashboard** and a new **Leased Dashboard**
+showing lease terms as an interactive Gantt chart alongside a table of
+leases.

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -6,6 +6,7 @@ app = Flask(__name__)
 
 # Determine the path to the Excel file relative to this file
 DATA_PATH = Path(__file__).resolve().parent.parent / '2025-6-20-iolp-buildings.xlsx'
+LEASE_DATA_PATH = Path(__file__).resolve().parent.parent / '2025-6-20-iolp-leases.xlsx'
 
 # Load a subset of the building dataset with relevant fields
 _df = pd.read_excel(
@@ -24,6 +25,32 @@ _df = pd.read_excel(
         'Congressional District Representative Name'
     ]
 )
+
+# Load leased property data with relevant fields and parse dates
+_leases_df = pd.read_excel(
+    LEASE_DATA_PATH,
+    usecols=[
+        'Real Property Asset Name',
+        'City',
+        'State',
+        'Lease Effective Date',
+        'Lease Expiration Date'
+    ],
+    parse_dates=['Lease Effective Date', 'Lease Expiration Date']
+)
+
+# Rename columns for cleaner JSON keys
+_leases_df = _leases_df.rename(columns={
+    'Real Property Asset Name': 'name',
+    'City': 'city',
+    'State': 'state',
+    'Lease Effective Date': 'lease_start',
+    'Lease Expiration Date': 'lease_end'
+})
+
+# Format dates as ISO strings for the web app
+_leases_df['lease_start'] = _leases_df['lease_start'].dt.strftime('%Y-%m-%d')
+_leases_df['lease_end'] = _leases_df['lease_end'].dt.strftime('%Y-%m-%d')
 
 # Combine address fields into a single column
 _df['Address'] = (
@@ -57,10 +84,22 @@ def properties_api():
     return jsonify(_df[['name', 'Address', 'construction_date', 'owned_or_leased']].to_dict(orient='records'))
 
 
+@app.route('/api/leases')
+def leases_api():
+    """Return leased property data for the dashboard."""
+    return jsonify(_leases_df.to_dict(orient='records'))
+
+
 @app.route('/owned')
 def owned_dashboard():
     """Render dashboard for owned properties."""
     return render_template('owned_dashboard.html')
+
+
+@app.route('/leased')
+def leased_dashboard():
+    """Render dashboard for leased properties."""
+    return render_template('leased_dashboard.html')
 
 
 @app.route('/api/owned_construction_dates')

--- a/webapp/templates/leased_dashboard.html
+++ b/webapp/templates/leased_dashboard.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Leased Properties Dashboard</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css" />
+    <link href="https://unpkg.com/vis-timeline@7.7.0/dist/vis-timeline-graph2d.min.css" rel="stylesheet" />
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
+    <script src="https://cdn.datatables.net/1.13.6/js/dataTables.bootstrap5.min.js"></script>
+    <script src="https://unpkg.com/vis-timeline@7.7.0/dist/vis-timeline-graph2d.min.js"></script>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">Asset Atlas</a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav">
+        <li class="nav-item"><a class="nav-link" href="/">Properties</a></li>
+        <li class="nav-item"><a class="nav-link disabled" href="#">Map</a></li>
+        <li class="nav-item"><a class="nav-link" href="/owned">Owned Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link active" aria-current="page" href="/leased">Leased Dashboard</a></li>
+      </ul>
+    </div>
+  </div>
+</nav>
+<div class="container">
+  <div class="card shadow-sm mb-4">
+    <div class="card-body">
+      <h1 class="card-title mb-4">Lease Terms</h1>
+      <div id="timeline"></div>
+    </div>
+  </div>
+  <div class="card shadow-sm">
+    <div class="card-body">
+      <h1 class="card-title mb-4">Leased Properties</h1>
+      <table id="leaseTable" class="table table-striped" style="width:100%">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>City</th>
+            <th>State</th>
+            <th>Lease Start</th>
+            <th>Lease End</th>
+          </tr>
+        </thead>
+      </table>
+    </div>
+  </div>
+</div>
+<script>
+$(function() {
+    $.getJSON('/api/leases', function(data) {
+        $('#leaseTable').DataTable({
+            data: data,
+            columns: [
+                { data: 'name' },
+                { data: 'city' },
+                { data: 'state' },
+                { data: 'lease_start' },
+                { data: 'lease_end' }
+            ],
+            pageLength: 25
+        });
+
+        var items = data.map(function(row, idx) {
+            return {
+                id: idx,
+                content: '',
+                start: row.lease_start,
+                end: row.lease_end,
+                title: row.name
+            };
+        });
+        var container = document.getElementById('timeline');
+        var timeline = new vis.Timeline(container, items, { stack: false });
+    });
+});
+</script>
+</body>
+</html>

--- a/webapp/templates/owned_dashboard.html
+++ b/webapp/templates/owned_dashboard.html
@@ -22,7 +22,7 @@
         <li class="nav-item"><a class="nav-link" href="/">Properties</a></li>
         <li class="nav-item"><a class="nav-link disabled" href="#">Map</a></li>
         <li class="nav-item"><a class="nav-link active" aria-current="page" href="/owned">Owned Dashboard</a></li>
-        <li class="nav-item"><a class="nav-link disabled" href="#">Leased Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="/leased">Leased Dashboard</a></li>
       </ul>
     </div>
   </div>

--- a/webapp/templates/properties.html
+++ b/webapp/templates/properties.html
@@ -22,7 +22,7 @@
         <li class="nav-item"><a class="nav-link active" aria-current="page" href="/">Properties</a></li>
         <li class="nav-item"><a class="nav-link disabled" href="#">Map</a></li>
         <li class="nav-item"><a class="nav-link" href="/owned">Owned Dashboard</a></li>
-        <li class="nav-item"><a class="nav-link disabled" href="#">Leased Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="/leased">Leased Dashboard</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add leased properties dataframe and routes to webapp
- create dashboard page with Gantt chart and table of leases
- enable navigation link to leased dashboard
- update README to mention new page

## Testing
- `python -m py_compile webapp/app.py`

------
https://chatgpt.com/codex/tasks/task_b_686466e28434832da31db13c59902c33